### PR TITLE
Simple typo fix for SolutionDir

### DIFF
--- a/src/Sake.Library/Sake.Library.csproj
+++ b/src/Sake.Library/Sake.Library.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Sake.Library</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">


### PR DESCRIPTION
Sake.Library.csproj had a bad SolutionDir path, modified to the correct path.
