### PR TITLE
Changed the default SRC path to '.' instead of src.

### DIFF
--- a/src/Sake.Library/Shared/_copy.shade
+++ b/src/Sake.Library/Shared/_copy.shade
@@ -7,7 +7,7 @@ default overwrite='${false}'
 
 
 @{
-  var copyFiles = Files.BasePath(sourceDir);
+  var copyFiles = Files.BasePath(Path.GetFullPath(sourceDir));
   if (!string.IsNullOrEmpty(include))
   {
     copyFiles = copyFiles.Include(include);

--- a/src/Sake.Library/Shared/_use-standard-goals.shade
+++ b/src/Sake.Library/Shared/_use-standard-goals.shade
@@ -13,7 +13,7 @@ default TARGET_DIR='${Path.Combine(BASE_DIR, "target")}'
 default BUILD_DIR='${Path.Combine(TARGET_DIR, "build")}'
 default TEST_DIR='${Path.Combine(TARGET_DIR, "test")}'
 
-default SRC='src'
+default SRC='.'
 default ASSEMBLYINFO_FILES='${Files.Include(SRC+"/**/AssemblyInfo.cs")}'
 default BUILD_PROJECTS='${Files.Include(SRC+"/**/*.csproj")}'
 default TEST_PROJECTS='${Files.Include(SRC+"/**/*.Tests.csproj")}'


### PR DESCRIPTION
- Use Path.GetFullPath to resolve '.' paths in _copy.
