### PR TITLE
Change the NuGet.exe to lower case

### DIFF
--- a/src/Sake.Library/Shared/_nuget-install.shade
+++ b/src/Sake.Library/Shared/_nuget-install.shade
@@ -1,5 +1,5 @@
 
-default nugetPath='.nuget/NuGet.exe'
+default nugetPath='.nuget/nuget.exe'
 
 default outputDir=''
 default packageVersion=''

--- a/src/Sake.Library/Shared/_nuget-pack.shade
+++ b/src/Sake.Library/Shared/_nuget-pack.shade
@@ -20,7 +20,7 @@ nugetPath='.nuget/NuGet.exe'
 
 */}
 
-default nugetPath='.nuget/NuGet.exe'
+default nugetPath='.nuget/nuget.exe'
 
 default outputDir=''
 default packageVersion=''

--- a/src/Sake.Library/Shared/_nuget-push.shade
+++ b/src/Sake.Library/Shared/_nuget-push.shade
@@ -1,5 +1,5 @@
 
-default nugetPath='.nuget/NuGet.exe'
+default nugetPath='.nuget/nuget.exe'
 
 default apiKey='${Environment.GetEnvironmentVariable("APIKEY")}'
 default extra=''


### PR DESCRIPTION
So as to support cross platform build for KRuntime, which download
NuGet.exe in lower case all time.

@davidfowl @loudej 

This issue is also mentioned in https://github.com/aspnet/KRuntime/pull/309
